### PR TITLE
Add new Telegram group link; fix ASD link.

### DIFF
--- a/FIUP_RULES.md
+++ b/FIUP_RULES.md
@@ -115,9 +115,10 @@ Ci trovate su:
 - Gruppi dedicati ai singoli corsi
   - [Analisi Matematica](https://t.me/joinchat/Afev3UAWaW0EpaabbOz4yQ)
   - [Programmazione](https://t.me/joinchat/CNmpL0LJL5CyHxOox9AZdw)
-  - [Algoritmi e Strutture Dati](https://t.me/unipd_asd)
+  - [Algoritmi e Strutture Dati](https://t.me/fiup_asd)
   - [Automi e Linguaggi Formali](https://t.me/joinchat/CCc5rEL9aeOT2jjcWpAv1w)
   - [Basi di Dati](https://t.me/basiunipd)
+  - [Probabilità e Statistica](https://t.me/fiup_prob)
   - [Programmazione ad Oggetti](https://t.me/joinchat/BNm1e0Ob23PCMKIAnOoq4g)
   - [Ingegneria del Software, coordinamento](https://t.me/joinchat/AanuJ0fOSgYWMoBPmSh-WQ)
   - [Programmazione Concorrente e Distribuita](https://t.me/unipd_pcd)


### PR DESCRIPTION
### Descrizione delle modifiche

Aggiunto il gruppo Telegram di Probabilità e Statistica, aggiornato il nuovo nome di quello di Algoritmi.